### PR TITLE
Tweaked absolute positioning

### DIFF
--- a/app/assets/javascripts/objects/app.js
+++ b/app/assets/javascripts/objects/app.js
@@ -26,7 +26,7 @@ var App = {
 			class: 'tooltip'
 		});
 
-		$('body').append(tooltip);
+		el.closest('a').append(tooltip);
 
 		var top = el.position().top + el.height();
 		var left = el.position().left;

--- a/app/assets/stylesheets/utilities/_tooltip.scss
+++ b/app/assets/stylesheets/utilities/_tooltip.scss
@@ -6,6 +6,7 @@
   padding: .25em;
   font-size: .8em;
   border-radius: 3px;
+  min-width: 50px;
 
   &:before {
     content: '';


### PR DESCRIPTION
So there was a couple of cases when appending to the body doesn't work for the tooltip. Specifically, in the bottom right "Posted By" box on a game's individual page. This should fix that up.